### PR TITLE
Enable code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ Thumbs.db
 # --------
 *.dll
 *.exe
+*.gcov

--- a/SimpleCppUnitTests.pro
+++ b/SimpleCppUnitTests.pro
@@ -2,6 +2,10 @@ QT += testlib
 QT += gui
 CONFIG += qt warn_on depend_includepath testcase
 
+# Code coverage is enabled in debug mode
+QMAKE_CXXFLAGS_DEBUG += -fprofile-arcs -ftest-coverage  # Compile with code coverage enabled
+QMAKE_LFLAGS_DEBUG += -lgcov --coverage                 # Link coverage profiler libraries
+
 TEMPLATE = app
 
 SOURCES +=  \


### PR DESCRIPTION
Enable code coverage using gcov.
Coverage is enabled only for unit tests in debug mode